### PR TITLE
Update GWOSC URL

### DIFF
--- a/OpenPhysicsTutorial.ipynb
+++ b/OpenPhysicsTutorial.ipynb
@@ -88,7 +88,7 @@
     "<samp>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</samp>\n",
     "\n",
     "\n",
-    "In this example, we will access [gravitational wave data](#H_23A7CB6A) from the [GWOSC](https://www.gw-openscience.org/) Open Science database.\n",
+    "In this example, we will access [gravitational wave data](#H_23A7CB6A) from the [GWOSC](https://gwosc.org/) Open Science database.\n",
     "\n",
     "<a name=\"H_E6AA057D\"></a>\n",
     "## Access the data\n",
@@ -108,7 +108,7 @@
    "execution_count": 1,
    "metadata": {},
    "source": [
-    "baseURL = \"https://www.gw-openscience.org/\";\n",
+    "baseURL = \"https://gwosc.org/\";\n",
     "archive = webread(baseURL+\"archive/all/json\");"
    ],
    "outputs": []

--- a/OpenPhysicsTutorialScript.m
+++ b/OpenPhysicsTutorialScript.m
@@ -66,7 +66,7 @@
 % 
 % 
 % 
-% In this example, we will access gravitational wave data from the <https://www.gw-openscience.org/ 
+% In this example, we will access gravitational wave data from the <https://gwosc.org/ 
 % GWOSC> Open Science database. 
 
 %% Access the data
@@ -75,7 +75,7 @@
 % Reading in archive of datafiles using API
 % Clear workspace and specify URL endpoints
 
-baseURL = "https://www.gw-openscience.org/";
+baseURL = "https://gwosc.org/";
 archive = webread(baseURL+"archive/all/json");
 
 % Read the archive of event files and sessions


### PR DESCRIPTION
Hello,

I'm working with the GWOSC. We are in the process of adding links to this tutorial but we have noticed that it uses the old URL (`www.gw-openscience.org`) which redirects to `gwosc.org`. This PR uses the new URL.